### PR TITLE
Fix stepsize and population referencing in DE algorithm

### DIFF
--- a/src/algorithms/DE/DE.jl
+++ b/src/algorithms/DE/DE.jl
@@ -68,8 +68,7 @@ function DE(;
     )
 
 
-    parameters =
-    DE(N, promote(F, CR, CR_min, CR_max, F_min, F_max)..., strategy)
+    parameters = DE(N, promote(F, CR, CR_min, CR_max, F_min, F_max)..., strategy)
 
     Algorithm(parameters; kargs...)
 
@@ -85,21 +84,15 @@ function update_state!(
         args...;
         kargs...
     )
-    population = status.population
-
-    F = parameters.F
-    CR = parameters.CR
 
 
-    rng = options.rng
     # stepsize
     if parameters.F_min < parameters.F_max
-        F = parameters.F_min + (parameters.F_max - parameters.F_min) * rand(rng)
+        parameters.F = parameters.F_min + (parameters.F_max - parameters.F_min) * rand(options.rng)
     end
 
     if parameters.CR_min < parameters.CR_max
-        CR =
-        parameters.CR_min + (parameters.CR_max - parameters.CR_min) * rand(rng)
+        parameters.CR = parameters.CR_min + (parameters.CR_max - parameters.CR_min) * rand(options.rng)
     end
 
     new_vectors = reproduction(status, parameters, problem)
@@ -203,7 +196,7 @@ function reproduction(status, parameters::AbstractDifferentialEvolution, problem
     F = parameters.F
     CR = parameters.CR
 
-    X = zeros(eltype(xBest), N,D)
+    X = zeros(eltype(xBest), N, D)
 
     for i in 1:N
         x = get_position(population[i])

--- a/src/algorithms/DE/DE.jl
+++ b/src/algorithms/DE/DE.jl
@@ -185,14 +185,14 @@ end
 
 
 function reproduction(status, parameters::AbstractDifferentialEvolution, problem)
-    @assert !isempty(status.population)
+    population = status.population
+    @assert !isempty(population)
 
     N = parameters.N
-    D = length(get_position(status.population[1]))
+    D = length(get_position(population[1]))
 
     strategy = parameters.strategy
     xBest = get_position(status.best_sol)
-    population = status.population
     F = parameters.F
     CR = parameters.CR
 
@@ -203,7 +203,7 @@ function reproduction(status, parameters::AbstractDifferentialEvolution, problem
         u = DE_mutation(population, F, strategy, 1)
         v = DE_crossover(x, u, CR)
         evo_boundary_repairer!(v, xBest, problem.search_space)
-        X[i,:] = _fix_type(v, problem.search_space)
+        X[i,:] .= _fix_type(v, problem.search_space)
     end
 
     X 


### PR DESCRIPTION
This pull request fixes two issues in the DE algorithm implementation:

1. The stepsize was not correctly written to the parameters in `update_state!`, resulting in incorrect behavior.

2. The population referencing was inconsistent in `reproduction`, so I just cleaned it up a little.
